### PR TITLE
Navigation Block

### DIFF
--- a/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
+++ b/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
@@ -151,7 +151,6 @@ class Navigation extends Block
      * @var array
      */
     public $allowedBlocks = [
-        'core/heading',
         'core/navigation',
     ];
 

--- a/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
+++ b/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
@@ -140,9 +140,8 @@ class Navigation extends Block
      */
     public $example = [
         'items' => [
-            ['item' => 'Item one'],
-            ['item' => 'Item two'],
-            ['item' => 'Item three'],
+            ['page' => 2], // Assumes page ID 2 exists (usually the sample page)
+            ['page' => 1], // Assumes page ID 1 exists (usually the homepage)
         ],
     ];
 

--- a/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
+++ b/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
@@ -47,7 +47,7 @@ class Navigation extends Block
      *
      * @var array
      */
-    public $post_types = ['post', 'page'];
+    public $post_types = [];
 
     /**
      * The parent block type allow list.
@@ -147,13 +147,13 @@ class Navigation extends Block
     ];
 
     /**
-     * The block template.
+     * Allowed blocks within this block
      *
      * @var array
      */
-    public $template = [
-        'core/heading' => ['placeholder' => 'Hello World'],
-        'core/paragraph' => ['placeholder' => 'Welcome to the Navigation block.'],
+    public $allowedBlocks = [
+        'core/heading',
+        'core/navigation',
     ];
 
     /**
@@ -163,6 +163,7 @@ class Navigation extends Block
     {
         return [
             'items' => $this->items(),
+            'allowedBlocks' => $this->allowedBlocks,
         ];
     }
 
@@ -175,7 +176,11 @@ class Navigation extends Block
 
         $fields
             ->addRepeater('items')
-                ->addText('item')
+                ->addPostObject('page', [
+                    'label' => 'Page',
+                    'post_type' => ['page'],
+                    'return_format' => 'id',
+                ])
             ->endRepeater();
 
         return $fields->build();

--- a/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
+++ b/site/web/app/themes/nynaeve/app/Blocks/Navigation.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Blocks;
+
+use Log1x\AcfComposer\Block;
+use Log1x\AcfComposer\Builder;
+
+class Navigation extends Block
+{
+    /**
+     * The block name.
+     *
+     * @var string
+     */
+    public $name = 'Navigation';
+
+    /**
+     * The block description.
+     *
+     * @var string
+     */
+    public $description = 'A beautiful Navigation block.';
+
+    /**
+     * The block category.
+     *
+     * @var string
+     */
+    public $category = 'theme';
+
+    /**
+     * The block icon.
+     *
+     * @var string|array
+     */
+    public $icon = 'editor-ul';
+
+    /**
+     * The block keywords.
+     *
+     * @var array
+     */
+    public $keywords = [];
+
+    /**
+     * The block post type allow list.
+     *
+     * @var array
+     */
+    public $post_types = ['post', 'page'];
+
+    /**
+     * The parent block type allow list.
+     *
+     * @var array
+     */
+    public $parent = [];
+
+    /**
+     * The ancestor block type allow list.
+     *
+     * @var array
+     */
+    public $ancestor = [];
+
+    /**
+     * The default block mode.
+     *
+     * @var string
+     */
+    public $mode = 'preview';
+
+    /**
+     * The default block alignment.
+     *
+     * @var string
+     */
+    public $align = '';
+
+    /**
+     * The default block text alignment.
+     *
+     * @var string
+     */
+    public $align_text = '';
+
+    /**
+     * The default block content alignment.
+     *
+     * @var string
+     */
+    public $align_content = '';
+
+    /**
+     * The default block spacing.
+     *
+     * @var array
+     */
+    public $spacing = [
+        'padding' => null,
+        'margin' => null,
+    ];
+
+    /**
+     * The supported block features.
+     *
+     * @var array
+     */
+    public $supports = [
+        'align' => false,
+        'align_text' => true,
+        'align_content' => true,
+        'full_height' => false,
+        'anchor' => true,
+        'mode' => true,
+        'multiple' => true,
+        'jsx' => true,
+        'color' => [
+            'background' => true,
+            'text' => true,
+            'gradients' => false,
+        ],
+        'spacing' => [
+            'padding' => true,
+            'margin' => true,
+        ],
+    ];
+
+    /**
+     * The block styles.
+     *
+     * @var array
+     */
+    public $styles = ['light', 'dark'];
+
+    /**
+     * The block preview example data.
+     *
+     * @var array
+     */
+    public $example = [
+        'items' => [
+            ['item' => 'Item one'],
+            ['item' => 'Item two'],
+            ['item' => 'Item three'],
+        ],
+    ];
+
+    /**
+     * The block template.
+     *
+     * @var array
+     */
+    public $template = [
+        'core/heading' => ['placeholder' => 'Hello World'],
+        'core/paragraph' => ['placeholder' => 'Welcome to the Navigation block.'],
+    ];
+
+    /**
+     * Data to be passed to the block before rendering.
+     */
+    public function with(): array
+    {
+        return [
+            'items' => $this->items(),
+        ];
+    }
+
+    /**
+     * The block field group.
+     */
+    public function fields(): array
+    {
+        $fields = Builder::make('navigation');
+
+        $fields
+            ->addRepeater('items')
+                ->addText('item')
+            ->endRepeater();
+
+        return $fields->build();
+    }
+
+    /**
+     * Retrieve the items.
+     *
+     * @return array
+     */
+    public function items()
+    {
+        return get_field('items') ?: $this->example['items'];
+    }
+
+    /**
+     * Assets enqueued when rendering the block.
+     */
+    public function assets(array $block): void
+    {
+        //
+    }
+}

--- a/site/web/app/themes/nynaeve/composer.json
+++ b/site/web/app/themes/nynaeve/composer.json
@@ -46,6 +46,7 @@
     "davidhsianturi/blade-bootstrap-icons": "^1.5",
     "generoi/sage-woocommerce": "^1.1",
     "khatabwedaa/blade-css-icons": "^1.4",
+    "log1x/acf-composer": "^3.3",
     "log1x/navi": "^3.1",
     "log1x/sage-svg": "^2.0",
     "owenvoke/blade-fontawesome": "^2.8",

--- a/site/web/app/themes/nynaeve/composer.lock
+++ b/site/web/app/themes/nynaeve/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b17c3867203f50d88e9759eb6cc8ab2",
+    "content-hash": "c40d0a531fe7f17173cc5072af79d497",
     "packages": [
         {
             "name": "blade-ui-kit/blade-icons",
@@ -2849,6 +2849,65 @@
             "time": "2024-09-21T08:32:55+00:00"
         },
         {
+            "name": "log1x/acf-composer",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Log1x/acf-composer.git",
+                "reference": "eb2d1bb43addecfddd64a4013b489e5576477a41"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Log1x/acf-composer/zipball/eb2d1bb43addecfddd64a4013b489e5576477a41",
+                "reference": "eb2d1bb43addecfddd64a4013b489e5576477a41",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/prompts": "*",
+                "php": "^8.0",
+                "stoutlogic/acf-builder": "^1.11"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.14",
+                "roots/acorn": "^3.0|^4.0"
+            },
+            "type": "package",
+            "extra": {
+                "acorn": {
+                    "providers": [
+                        "Log1x\\AcfComposer\\Providers\\AcfComposerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Log1x\\AcfComposer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brandon Nifong",
+                    "email": "brandon@tendency.me"
+                }
+            ],
+            "description": "Create fields, blocks, option pages, and widgets using ACF Builder and Sage 10",
+            "support": {
+                "issues": "https://github.com/Log1x/acf-composer/issues",
+                "source": "https://github.com/Log1x/acf-composer/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Log1x",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-18T07:29:05+00:00"
+        },
+        {
             "name": "log1x/navi",
             "version": "v3.1.1",
             "source": {
@@ -4207,6 +4266,52 @@
                 }
             ],
             "time": "2024-05-08T21:05:03+00:00"
+        },
+        {
+            "name": "stoutlogic/acf-builder",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/StoutLogic/acf-builder.git",
+                "reference": "e63ab87233ea3675cd519f1dd6b6d4230b3cef97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/StoutLogic/acf-builder/zipball/e63ab87233ea3675cd519f1dd6b6d4230b3cef97",
+                "reference": "e63ab87233ea3675cd519f1dd6b6d4230b3cef97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.1|^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "2.*",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "^2.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StoutLogic\\AcfBuilder\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Steve Pfisterer",
+                    "email": "steve@stoutlogic.com"
+                }
+            ],
+            "description": "An Advanced Custom Field Configuration Builder",
+            "support": {
+                "issues": "https://github.com/StoutLogic/acf-builder/issues",
+                "source": "https://github.com/StoutLogic/acf-builder/tree/v1.12.0"
+            },
+            "time": "2021-09-17T17:32:44+00:00"
         },
         {
             "name": "symfony/console",

--- a/site/web/app/themes/nynaeve/config/acf.php
+++ b/site/web/app/themes/nynaeve/config/acf.php
@@ -1,0 +1,67 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Field Type Settings
+    |--------------------------------------------------------------------------
+    |
+    | Here you can set default field group and field type configuration that
+    | is then merged with your field groups when they are composed.
+    |
+    | This allows you to avoid the repetitive process of setting common field
+    | configuration such as `ui` on every `trueFalse` field or your
+    | preferred `instruction_placement` on every `fieldGroup`.
+    |
+    */
+
+    'defaults' => [
+        // 'trueFalse' => ['ui' => 1],
+        // 'select' => ['ui' => 1],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Field Types
+    |--------------------------------------------------------------------------
+    |
+    | Here you can define custom field types that are not included with ACF
+    | out of the box. This allows you to use the fluent builder pattern with
+    | custom field types such as `addEditorPalette()`.
+    |
+    */
+
+    'types' => [
+        // 'editorPalette' => 'editor_palette',
+        // 'phoneNumber' => 'phone_number',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Generators
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify defaults used when generating Composer classes in
+    | your application.
+    |
+    */
+
+    'generators' => [
+        'supports' => ['align', 'mode', 'multiple', 'jsx'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Manifest Path
+    |--------------------------------------------------------------------------
+    |
+    | Here you can define the cache manifest path. Fields are typically cached
+    | when running the `acf:cache` command. This will cache the built field
+    | groups and potentially improve performance in complex applications.
+    |
+    */
+
+    'manifest' => storage_path('framework/cache'),
+
+];

--- a/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
+++ b/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
@@ -1,0 +1,15 @@
+<div class="{{ $block->classes }}" style="{{ $block->inlineStyle }}">
+  @if ($items)
+    <ul>
+      @foreach ($items as $item)
+        <li>{{ $item['item'] }}</li>
+      @endforeach
+    </ul>
+  @else
+    <p>{{ $block->preview ? 'Add an item...' : 'No items found!' }}</p>
+  @endif
+
+  <div>
+    <InnerBlocks template="{{ $block->template }}" />
+  </div>
+</div>

--- a/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
+++ b/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
@@ -2,7 +2,9 @@
   @if ($items)
     <ul>
       @foreach ($items as $item)
-        <li>{{ $item['item'] }}</li>
+        @if (isset($item['page']))
+          <li><a href="{{ get_permalink($item['page']) }}">{{ get_the_title($item['page']) }}</a></li>
+        @endif
       @endforeach
     </ul>
   @else
@@ -10,6 +12,6 @@
   @endif
 
   <div>
-    <InnerBlocks template="{{ $block->template }}" />
+    <InnerBlocks allowedBlocks="{{ json_encode($allowedBlocks) }}" />
   </div>
 </div>

--- a/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
+++ b/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
@@ -10,8 +10,4 @@
   @else
     <p>{{ $block->preview ? 'Add an item...' : 'No items found!' }}</p>
   @endif
-
-  <div>
-    <InnerBlocks allowedBlocks="{{ json_encode($allowedBlocks) }}" />
-  </div>
 </div>

--- a/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
+++ b/site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php
@@ -3,7 +3,7 @@
     <ul>
       @foreach ($items as $item)
         @if (isset($item['page']))
-          <li><a href="{{ get_permalink($item['page']) }}">{{ get_the_title($item['page']) }}</a></li>
+          <li><a href="{{ get_permalink($item['page']) }}">{{ html_entity_decode(get_the_title($item['page'])) }}</a></li>
         @endif
       @endforeach
     </ul>


### PR DESCRIPTION
This pull request introduces a new `Navigation` block to the theme. Added because such a block was missing for the widgets section and legacy widgets are never the solution.

The most important changes include the addition of the `Navigation` block class, updates to the `composer.json` file to include necessary dependencies, configuration for ACF (Advanced Custom Fields), and the creation of a Blade template for rendering the navigation block.

### Addition of the `Navigation` block:

* [`site/web/app/themes/nynaeve/app/Blocks/Navigation.php`](diffhunk://#diff-5147f00ca0c5bc32836e856ff07fad7423fc28fc9f77637544653443f717c2bfR1-R204): Added a new `Navigation` block class with properties for block settings and methods for rendering and managing block data.

### Dependency updates:

* [`site/web/app/themes/nynaeve/composer.json`](diffhunk://#diff-7f566bdfcbd114ac22cc6da45b12961539fea4235a0ac8d01c2e5f906f5b52d3R49): Added `log1x/acf-composer` as a dependency to support the new block.

### ACF configuration:

* [`site/web/app/themes/nynaeve/config/acf.php`](diffhunk://#diff-cafd86c2b0096aa7c246f935093d624c3d25a2f8784bf6213e8994b99b7be0c7R1-R67): Added configuration for default field type settings, custom field types, generators, and cache manifest path for ACF.

### Blade template for block rendering:

* [`site/web/app/themes/nynaeve/resources/views/blocks/navigation.blade.php`](diffhunk://#diff-b238127e022dd062fff3a11db0bb2a3045a4b73e56474bbc1d1da7249852120eR1-R13): Created a Blade template for rendering the `Navigation` block with a list of navigation items.