### PR TITLE
WooCommerce Account lockdown

### DIFF
--- a/site/web/app/themes/nynaeve/app/setup.php
+++ b/site/web/app/themes/nynaeve/app/setup.php
@@ -175,7 +175,7 @@ add_action('woocommerce_single_product_summary', function() {
 
 // Redirect users from cart and checkout pages since they're not needed
 add_action('template_redirect', function() {
-    if (is_cart() || is_checkout()) {
+    if (is_cart() || is_checkout() || is_account_page()) {
         wp_redirect(home_url());
         exit;
     }


### PR DESCRIPTION
This pull request includes a change to the `site/web/app/themes/nynaeve/app/setup.php` file. The change ensures that users are also redirected from the account page, in addition to the cart and checkout pages, as they are not needed.

* [`site/web/app/themes/nynaeve/app/setup.php`](diffhunk://#diff-97c570e69b614ba1cf596c279b1c9acc53677d2c3f346c645ca2d78357e8831fL178-R178): Modified the redirect condition to include the account page by adding `is_account_page()` to the if statement.