### PR TITLE
Header Icons URL Update

### DIFF
--- a/site/web/app/themes/nynaeve/resources/views/components/navigation.blade.php
+++ b/site/web/app/themes/nynaeve/resources/views/components/navigation.blade.php
@@ -70,11 +70,11 @@
       
       <div class="flex items-center" id="nav-content">
          <!-- facebook icon -->
-        <a class="inline-block no-underline " href="/my-account/" aria-label="Facebook Account">
+        <a class="inline-block no-underline " href="https://www.facebook.com/imagewize/" aria-label="Facebook Account">
         <x-css-facebook class="fill-current text-white hover:text-textBodyGray w-6 h-6 ml-3" />
         </a>
         <!-- github icons -->
-        <a class="pl-3 inline-block no-underline" href="/cart" aria-label="Github">
+        <a class="pl-3 inline-block no-underline" href="https://github.com/imagewize/" aria-label="Github">
           <x-bi-github class="text-white hover:text-textBodyGray" />
         </a>
       </div>


### PR DESCRIPTION
This pull request includes updates to the navigation links in the `site/web/app/themes/nynaeve/resources/views/components/navigation.blade.php` file. The most important changes involve updating the URLs for the Facebook and GitHub links to point to the correct external pages.

Updates to navigation links:

* [`site/web/app/themes/nynaeve/resources/views/components/navigation.blade.php`](diffhunk://#diff-f0efdc451ecd74888bf7adeb6bbadc03d7f143c67ab1dd3bb22476fc3ba52ab0L73-R77): Updated the Facebook link to point to the correct external URL `https://www.facebook.com/imagewize/`.
* [`site/web/app/themes/nynaeve/resources/views/components/navigation.blade.php`](diffhunk://#diff-f0efdc451ecd74888bf7adeb6bbadc03d7f143c67ab1dd3bb22476fc3ba52ab0L73-R77): Updated the GitHub link to point to the correct external URL `https://github.com/imagewize/`.