### PR TITLE
Build Before w/ Sage Hook Activation

### DIFF
--- a/trellis/deploy-hooks/build-before.yml
+++ b/trellis/deploy-hooks/build-before.yml
@@ -6,39 +6,39 @@
 # Uncomment the lines below if you are using Sage 10
 # and replace `sage` with your theme folder
 #
-# ---
-# - name: Install npm dependencies
-#   command: yarn
-#   delegate_to: localhost
-#   args:
-#     chdir: "{{ project_local_path }}/web/app/themes/sage"
-#
-# - name: Install Composer dependencies
-#   command: composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts --classmap-authoritative
-#   args:
-#     chdir: "{{ deploy_helper.new_release_path }}/web/app/themes/sage"
-#
-# - name: Compile assets for production
-#   command: yarn build
-#   delegate_to: localhost
-#   args:
-#     chdir: "{{ project_local_path }}/web/app/themes/sage"
-#
-# - name: Check for entrypoints
-#   stat:
-#     path: "{{ project_local_path }}/web/app/themes/sage/public/entrypoints.json"
-#   delegate_to: localhost
-#   register: entrypoints_data
+---
+- name: Install npm dependencies
+  command: yarn
+  delegate_to: localhost
+  args:
+    chdir: "{{ project_local_path }}/web/app/themes/nynaeve"
 
-# - name: Entrypoints missing
-#   ansible.builtin.fail:
-#     msg: "The theme is missing the public/entrypoints.json file"
-#   when: not entrypoints_data.stat.exists
-#
-# - name: Copy production assets
-#   synchronize:
-#     src: "{{ project_local_path }}/web/app/themes/sage/public"
-#     dest: "{{ deploy_helper.new_release_path }}/web/app/themes/sage"
-#     group: no
-#     owner: no
-#     rsync_opts: --chmod=Du=rwx,--chmod=Dg=rx,--chmod=Do=rx,--chmod=Fu=rw,--chmod=Fg=r,--chmod=Fo=r
+- name: Install Composer dependencies
+  command: composer install --no-ansi --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts --classmap-authoritative
+  args:
+    chdir: "{{ deploy_helper.new_release_path }}/web/app/themes/nynaeve"
+
+- name: Compile assets for production
+  command: yarn build
+  delegate_to: localhost
+  args:
+    chdir: "{{ project_local_path }}/web/app/themes/nynaeve"
+
+- name: Check for entrypoints
+  stat:
+    path: "{{ project_local_path }}/web/app/themes/nynaeve/public/entrypoints.json"
+  delegate_to: localhost
+  register: entrypoints_data
+
+- name: Entrypoints missing
+  ansible.builtin.fail:
+    msg: "The theme is missing the public/entrypoints.json file"
+  when: not entrypoints_data.stat.exists
+
+- name: Copy production assets
+  synchronize:
+    src: "{{ project_local_path }}/web/app/themes/nynaeve/public"
+    dest: "{{ deploy_helper.new_release_path }}/web/app/themes/nynaeve"
+    group: no
+    owner: no
+    rsync_opts: --chmod=Du=rwx,--chmod=Dg=rx,--chmod=Do=rx,--chmod=Fu=rw,--chmod=Fg=r,--chmod=Fo=r


### PR DESCRIPTION
This pull request modifies the `trellis/deploy-hooks/build-before.yml` file to update the theme folder references from `sage` to `nynaeve`. The changes include uncommenting and modifying several deployment tasks.

Key changes:

* Updated the `Install npm dependencies` task to use the `nynaeve` theme folder instead of `sage`.
* Updated the `Install Composer dependencies` task to use the `nynaeve` theme folder instead of `sage`.
* Updated the `Compile assets for production` task to use the `nynaeve` theme folder instead of `sage`.
* Updated the `Check for entrypoints` task to use the `nynaeve` theme folder instead of `sage`.
* Updated the `Copy production assets` task to use the `nynaeve` theme folder instead of `sage`.