### PR TITLE
Main Branch for Deployment

### DIFF
--- a/trellis/group_vars/production/wordpress_sites.yml
+++ b/trellis/group_vars/production/wordpress_sites.yml
@@ -8,7 +8,7 @@ wordpress_sites:
       redirects:
       - www.imagewize.com
     local_path: ../site
-    branch: master
+    branch: main
     repo: git@github.com:imagewize/imagewize.com.git
     repo_subtree_path: site
     multisite:


### PR DESCRIPTION
This pull request includes a small but important change to the `trellis/group_vars/production/wordpress_sites.yml` file. The change updates the branch name from `master` to `main`.

* [`trellis/group_vars/production/wordpress_sites.yml`](diffhunk://#diff-29a588580a2d58aedc6af896e3ed16e7cb7c1d0e2b2bf9ef03d082391754bdb8L11-R11): Changed the branch name from `master` to `main` in the `wordpress_sites` configuration.