### PR TITLE
IPv4 Address instead of Domain Name

### DIFF
--- a/trellis/hosts/production
+++ b/trellis/hosts/production
@@ -2,7 +2,7 @@
 # List each machine only once per [group], even if it will host multiple sites.
 
 [production]
-imagewize.com
+188.245.200.144
 
 [web]
-imagewize.com
+188.245.200.144


### PR DESCRIPTION
This pull request includes changes to the `trellis/hosts/production` file to replace domain names with IP addresses for the production and web groups.

This change ensures that Ansible will connect directly to your server using its IP address, which is more reliable than using the domain name. The domain name configuration in wordpress_sites.yml remains unchanged as that's used for the actual site configuration rather than server access.

Network configuration updates:

* [`trellis/hosts/production`](diffhunk://#diff-a93787d954ae30dd64f439ae2abc1063d7a7636ab6c4128d64a0d9b7627707eeL5-R8): Replaced the domain name `imagewize.com` with the IP address `188.245.200.144` in both the `[production]` and `[web]` groups.