### PR TITLE
FastCGI Cache

### DIFF
--- a/trellis/group_vars/production/wordpress_sites.yml
+++ b/trellis/group_vars/production/wordpress_sites.yml
@@ -17,4 +17,6 @@ wordpress_sites:
       enabled: true
       provider: letsencrypt
     cache:
-      enabled: false
+      enabled: true
+      skip_cache_uri: /wp-admin/|/wp-json/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml|/store.*|/cart.*|/my-account.*|/checkout.*|/addons.*
+      skip_cache_cookie: comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_cart_hash|woocommerce_items_in_cart|wp_woocommerce_session_


### PR DESCRIPTION
This pull request includes a change to the `trellis/group_vars/production/wordpress_sites.yml` file to enable caching and specify the URIs and cookies to be skipped by the cache.

Caching configuration:

* [`trellis/group_vars/production/wordpress_sites.yml`](diffhunk://#diff-29a588580a2d58aedc6af896e3ed16e7cb7c1d0e2b2bf9ef03d082391754bdb8L20-R22): Enabled caching and added `skip_cache_uri` and `skip_cache_cookie` settings to exclude certain URIs and cookies from being cached.