### PR TITLE
PHP FPM Resources Increase

### DIFF
--- a/trellis/roles/wordpress-setup/defaults/main.yml
+++ b/trellis/roles/wordpress-setup/defaults/main.yml
@@ -50,8 +50,8 @@ robots_tag_header_enabled: "{{ robots_tag_header.enabled | default(not_prod) }}"
 
 # PHP FPM
 php_fpm_pm: 'dynamic'
-php_fpm_pm_max_children: 10
-php_fpm_pm_start_servers: 1
-php_fpm_pm_min_spare_servers: 1
-php_fpm_pm_max_spare_servers: 3
+php_fpm_pm_max_children: 15
+php_fpm_pm_start_servers: 3
+php_fpm_pm_min_spare_servers: 3
+php_fpm_pm_max_spare_servers: 5
 php_fpm_pm_max_requests: 500


### PR DESCRIPTION
This pull request includes changes to the `trellis/roles/wordpress-setup/defaults/main.yml` file to adjust the PHP-FPM settings for better performance. The most important changes include increasing the maximum number of child processes, the number of start servers, and the number of spare servers.

Performance improvements for PHP-FPM:

* Increased `php_fpm_pm_max_children` from 10 to 15 to allow more concurrent child processes.
* Increased `php_fpm_pm_start_servers` from 1 to 3 to start more servers initially.
* Increased `php_fpm_pm_min_spare_servers` from 1 to 3 to maintain a higher minimum number of spare servers.
* Increased `php_fpm_pm_max_spare_servers` from 3 to 5 to allow more spare servers to handle sudden traffic spikes.