### PR TITLE
PHP Children and Servers Increase

### DIFF
--- a/trellis/roles/wordpress-setup/defaults/main.yml
+++ b/trellis/roles/wordpress-setup/defaults/main.yml
@@ -50,8 +50,8 @@ robots_tag_header_enabled: "{{ robots_tag_header.enabled | default(not_prod) }}"
 
 # PHP FPM
 php_fpm_pm: 'dynamic'
-php_fpm_pm_max_children: 10
-php_fpm_pm_start_servers: 1
-php_fpm_pm_min_spare_servers: 1
-php_fpm_pm_max_spare_servers: 3
+php_fpm_pm_max_children: 30
+php_fpm_pm_start_servers: 6
+php_fpm_pm_min_spare_servers: 4
+php_fpm_pm_max_spare_servers: 10
 php_fpm_pm_max_requests: 500


### PR DESCRIPTION
This pull request includes changes to optimize the PHP FPM configuration in the `trellis/roles/wordpress-setup/defaults/main.yml` file. The adjustments aim to improve the performance and scalability of the PHP FPM setup.

Performance and scalability improvements:

* Increased `php_fpm_pm_max_children` from 10 to 30 to allow more concurrent child processes.
* Increased `php_fpm_pm_start_servers` from 1 to 6 to start more servers initially.
* Increased `php_fpm_pm_min_spare_servers` from 1 to 4 to maintain a higher number of idle servers ready to handle requests.
* Increased `php_fpm_pm_max_spare_servers` from 3 to 10 to allow more idle servers before scaling down.