### PR TITLE
Post Code Blocks Word Wrap

### DIFF
--- a/site/web/app/themes/nynaeve/resources/styles/app.css
+++ b/site/web/app/themes/nynaeve/resources/styles/app.css
@@ -34,7 +34,7 @@
 */
 
 code {
-  @apply text-sm whitespace-nowrap bg-gray-100 border-gray-200 border-2 rounded-sm font-menlo text-gray-800;
+  @apply text-sm whitespace-normal break-words bg-gray-100 border-gray-200 border-2 rounded-sm font-menlo text-gray-800;
 }
 
 pre > code {


### PR DESCRIPTION
This pull request includes a small change to the `site/web/app/themes/nynaeve/resources/styles/app.css` file. The change modifies the `code` CSS class to allow text wrapping within code blocks.

* [`site/web/app/themes/nynaeve/resources/styles/app.css`](diffhunk://#diff-4de747d3d56fdd25501afa2dae42c81c41f00e12c86bae93d308a952a23a1297L37-R37): Changed `whitespace-nowrap` to `whitespace-normal` and added `break-words` to allow text wrapping within code blocks.