### PR TITLE
Code Blocks Medium+ Screens X Axis Margin

### DIFF
--- a/site/web/app/themes/nynaeve/resources/styles/app.css
+++ b/site/web/app/themes/nynaeve/resources/styles/app.css
@@ -42,7 +42,7 @@ pre > code {
 }
 
 .wp-block-code {
-  @apply my-5 rounded-md bg-gray-100 pt-5 px-6 pb-6;
+  @apply my-5 rounded-md bg-gray-100 pt-5 px-6 pb-6 md:mx-5;
 }
 
 .post .wp-block-latest-posts__list {


### PR DESCRIPTION
This pull request includes a small change to the `site/web/app/themes/nynaeve/resources/styles/app.css` file. The change modifies the `.wp-block-code` class to include a new margin class for medium-sized screens.

* [`site/web/app/themes/nynaeve/resources/styles/app.css`](diffhunk://#diff-4de747d3d56fdd25501afa2dae42c81c41f00e12c86bae93d308a952a23a1297L45-R45): Added `md:mx-5` to the `.wp-block-code` class to adjust margins on medium-sized screens.