### PR TITLE
PHP Memory Limit Increase

### DIFF
--- a/trellis/roles/php/defaults/main.yml
+++ b/trellis/roles/php/defaults/main.yml
@@ -10,7 +10,7 @@ php_display_startup_errors: 'Off'
 php_max_execution_time: 120
 php_max_input_time: 300
 php_max_input_vars: 1000
-php_memory_limit: 96M
+php_memory_limit: 256M  # Increase from default value (likely 96M or 128M)
 php_cli_memory_limit: -1
 php_mysqlnd_collect_memory_statistics: 'Off'
 php_post_max_size: 25M


### PR DESCRIPTION
This pull request includes a change to the `trellis/roles/php/defaults/main.yml` file to increase the PHP memory limit. 

* [`trellis/roles/php/defaults/main.yml`](diffhunk://#diff-68f2aadde15061a6f8ec2c091d40a24281ddf153a56413bf1e36076664f4fefdL13-R13): Increased the `php_memory_limit` from 96M to 256M to accommodate higher memory requirements.