### PR TITLE
Build before with npm & Build After Activation

### DIFF
--- a/trellis/deploy-hooks/build-after.yml
+++ b/trellis/deploy-hooks/build-after.yml
@@ -1,12 +1,12 @@
 # Placeholder `deploy_build_after` hook
 #
-# ⚠️ This example assumes your theme is using Sage 10
+# ⚠️ This example assumes your theme is using Sage 11
 #
-# Uncomment the lines below if you are using Sage 10
+# Uncomment the lines below if you are using Sage 11
 # NOTE: this task will fail if Sage theme is not activated at time of deployment.
 #
-# ---
-# - name: Run Acorn optimize
-#   command: wp acorn optimize
-#   args:
-#     chdir: "{{ deploy_helper.new_release_path }}"
+---
+- name: Run Acorn optimize
+  command: wp acorn optimize
+  args:
+    chdir: "{{ deploy_helper.new_release_path }}"

--- a/trellis/deploy-hooks/build-before.yml
+++ b/trellis/deploy-hooks/build-before.yml
@@ -8,7 +8,7 @@
 #
 ---
 - name: Install npm dependencies
-  command: yarn
+  command: npm install
   delegate_to: localhost
   args:
     chdir: "{{ project_local_path }}/web/app/themes/nynaeve"
@@ -19,7 +19,7 @@
     chdir: "{{ deploy_helper.new_release_path }}/web/app/themes/nynaeve"
 
 - name: Compile assets for production
-  command: yarn build
+  command: npm run build
   delegate_to: localhost
   args:
     chdir: "{{ project_local_path }}/web/app/themes/nynaeve"


### PR DESCRIPTION
This pull request includes updates to the `trellis/deploy-hooks` configuration files to reflect changes in dependencies and build processes. The most important changes involve updating the theme version assumption and switching from `yarn` to `npm` for dependency management and asset compilation.

Updates to theme version assumption:

* [`trellis/deploy-hooks/build-after.yml`](diffhunk://#diff-a2289af80bb78ebd315ba85cd44510f0bcc8b683bdaf3eca472ea3888b270fccL3-R12): Updated comments to assume the theme is using Sage 11 instead of Sage 10.

Switch from `yarn` to `npm`:

* [`trellis/deploy-hooks/build-before.yml`](diffhunk://#diff-3e49237252a201a217b0168a32918b717672384d047a5aeb6cd6fbba0e28b5e5L11-R11): Changed the command for installing npm dependencies from `yarn` to `npm install`.
* [`trellis/deploy-hooks/build-before.yml`](diffhunk://#diff-3e49237252a201a217b0168a32918b717672384d047a5aeb6cd6fbba0e28b5e5L22-R22): Updated the command for compiling assets for production from `yarn build` to `npm run build`.